### PR TITLE
Fixed one-to-many relationship and update

### DIFF
--- a/api/mergedData.js
+++ b/api/mergedData.js
@@ -1,0 +1,14 @@
+import { getSinglePalette } from './paletteData';
+import { getPalettedColors } from './palettedColorsData';
+
+const viewPaletteColors = (paletteFbK) => new Promise((resolve, reject) => {
+  getSinglePalette(paletteFbK)
+    .then((paletteObj) => {
+      getPalettedColors(paletteObj.fbK)
+        .then((colorObj) => {
+          resolve({ colorObj, ...paletteObj });
+        });
+    }).catch((error) => reject(error));
+});
+
+export default viewPaletteColors;

--- a/api/palettedColorsData.js
+++ b/api/palettedColorsData.js
@@ -1,0 +1,43 @@
+const endpoint = 'https://colourette-default-rtdb.firebaseio.com';
+
+const createPalettedColors = (payload) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/palettedColors.json`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  }).then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+
+const updatePalettedColors = (payload) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/palettedColors/${payload.fbK}.json`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  }).then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+
+const getPalettedColors = (fbK) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/palettedColors.json?orderBy="paletteId"&equalTo="${fbK}"`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }).then((response) => response.json())
+    .then((data) => {
+      if (data) {
+        resolve(Object.values(data));
+      } else {
+        resolve([]);
+      }
+    }).catch(reject);
+});
+
+export { createPalettedColors, updatePalettedColors, getPalettedColors };

--- a/components/ColorBox.js
+++ b/components/ColorBox.js
@@ -1,12 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+// import { Button } from 'react-bootstrap';
 
 function ColorBox({ color }) {
+  // const [lock, setLock] = useState(false);
+  // const [prevData, setPrevData] = useState([]);
+
+  // const handleUnlock = () => setLock(false);
+  // const handleLock = () => setLock(true);
+
+  // const lockColors = (e) => {
+  //   e.preventDefault();
+  //   console.warn('this is e', e);
+  //   console.warn('this is lock', lock);
+  //   if (e.target.value === 'LOCK') {
+  //     // e.preventDefault();
+  //     setLock(true);
+  //   } else if (e.target.value === 'UNLOCK') {
+  //     setLock(false);
+  //   }
+  // };
+
   return (
     <>
       <div className="gen-page-flow">
         <h3>{color}</h3>
         <div className="color-box" style={{ backgroundColor: `${color}` }} />
+        {/* <Button size="sm" type="submit" className="mt-1 mb-3 lock-btn" onClick={lockColors}>LOCK</Button> */}
       </div>
     </>
   );

--- a/components/ColorCard.js
+++ b/components/ColorCard.js
@@ -17,7 +17,7 @@ function ColorCard({ colorObj }) {
         </Card.Title>
         <div className="text-center">
           <Link href={`/color/${colorObj.fbK}`} passHref>
-            <Button className="basic-btn">VIEW</Button>
+            <Button className="basic-btn bg-black">👀</Button>
           </Link>
         </div>
       </Card.Body>
@@ -30,6 +30,7 @@ ColorCard.propTypes = {
     fbK: PropTypes.string,
     name: PropTypes.string,
     hex: PropTypes.string,
+    id: PropTypes.number,
   }).isRequired,
 };
 

--- a/components/PaletteBox.js
+++ b/components/PaletteBox.js
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-const */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from 'react-bootstrap';
 import NewPaletteForm from './forms/NewPaletteForm';
 import ColorBox from './ColorBox';
@@ -15,6 +15,11 @@ function PaletteBox() {
     }
     setColors(arr);
   };
+
+  useEffect(() => {
+    randomColor();
+  }, []);
+
   return (
     <>
       <div className="palette-container text-center">
@@ -25,9 +30,11 @@ function PaletteBox() {
             ))
           }
         </div>
-        <Button variant="danger" className="generate-btn" onClick={() => randomColor()}>RANDOMIZE</Button>
+        <div className="mt-3">
+          <Button variant="danger" size="lg" style={{ marginRight: '5px' }} className="basic-btn" onClick={() => randomColor()}>RANDOMIZE</Button>
+          <NewPaletteForm colors={colors} />
+        </div>
       </div>
-      <NewPaletteForm colors={colors} />
     </>
   );
 }

--- a/components/PaletteCard.js
+++ b/components/PaletteCard.js
@@ -13,21 +13,23 @@ function PaletteCard({ paletteObj, onUpdate }) {
 
   return (
     <Card style={{
-      width: '18rem', margin: '10px', backgroundColor: 'darkgrey', color: 'white',
+      width: '18rem', margin: '10px', backgroundColor: 'darkgrey', color: 'white', height: '210px',
     }}
     >
       <Card.Body className="text-center">
         <Card.Title className="text-center">
           {paletteObj.title}
         </Card.Title>
-        <CardText>
-          {paletteObj.description}
-        </CardText>
-        <div className="text-center btn-group">
+        <div style={{ height: '100px', overflow: 'scroll' }} className="mb-2">
+          <CardText>
+            {paletteObj.description}
+          </CardText>
+        </div>
+        <div className="text-center btn-group palette-btn">
           <Link href={`/palette/${paletteObj.fbK}`} passHref>
-            <Button className="basic-btn">VIEW</Button>
+            <Button className="basic-btn">👀</Button>
           </Link>
-          <Button variant="danger" className="basic-btn" onClick={removePalette}>DEL</Button>
+          <Button variant="danger" className="basic-btn" onClick={removePalette}>🗑️</Button>
         </div>
       </Card.Body>
     </Card>

--- a/components/forms/NewColorForm.js
+++ b/components/forms/NewColorForm.js
@@ -37,6 +37,7 @@ function NewColorForm() {
     <div className="text-center">
       <Form className="color-form" onSubmit={handleSubmit}>
         <h1 className="mt-5">Add a Color!</h1>
+        <hr className="w-25 center mb-3" />
         <Form.Group className="mt-4 mb-3 form-input" controlId="ControlInput1">
           <Form.Label>Color Name</Form.Label>
           <Form.Control
@@ -51,7 +52,7 @@ function NewColorForm() {
         <Form.Group className="mb-3 form-input" controlId="ControlTextarea1">
           <Form.Label>Hex Code</Form.Label>
           <br />
-          <Form.Text>Hex value ONLY, nothing else please!</Form.Text>
+          <Form.Text>Value Only</Form.Text>
           <Form.Control
             className="input-field"
             type="text"

--- a/pages/color/view.js
+++ b/pages/color/view.js
@@ -26,7 +26,7 @@ export default function ViewColors() {
       </div>
       <div className="d-flex flex-wrap justify-content-center">
         {colors?.map((color) => (
-          <ColorCard key={color.fbK} colorObj={color} onUpdate={getAllColors} />
+          <ColorCard key={color.id} colorObj={color} onUpdate={getAllColors} />
         ))}
       </div>
     </>

--- a/pages/palette/[fbK].js
+++ b/pages/palette/[fbK].js
@@ -1,21 +1,27 @@
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
-import { Button } from 'react-bootstrap';
 import { getSinglePalette } from '../../api/paletteData';
 import NewPaletteForm from '../../components/forms/NewPaletteForm';
+import { getPalettedColors } from '../../api/palettedColorsData';
 
 function ViewPalette() {
   const [paletteDetails, setPaletteDetails] = useState({});
+  const [palettedColors, setPalettedColors] = useState([]);
   const router = useRouter();
   const { fbK } = router.query;
 
   const getDetails = () => {
-    getSinglePalette(fbK).then(setPaletteDetails);
+    getSinglePalette(fbK).then((details) => {
+      setPaletteDetails(details);
+      getPalettedColors(details.fbK).then((colors) => {
+        setPalettedColors(colors);
+      });
+    });
   };
 
   useEffect(() => {
     getDetails();
-  });
+  }, [fbK, paletteDetails]);
 
   return (
     <>
@@ -28,30 +34,33 @@ function ViewPalette() {
       </div>
       <div className="d-flex flex-column">
         <div className="d-flex flex-wrap justify-content-center gap-5">
-          <div className="d-flex flex-column text-center">
-            <div className="color-display" style={{ backgroundColor: `${paletteDetails.hex1}` }} />
-            <h4>{paletteDetails.hex1}</h4>
-          </div>
-          <div className="d-flex flex-column text-center">
-            <div className="color-display" style={{ backgroundColor: `${paletteDetails.hex2}` }} />
-            <h4>{paletteDetails.hex2}</h4>
-          </div>
-          <div className="d-flex flex-column text-center">
-            <div className="color-display" style={{ backgroundColor: `${paletteDetails.hex3}` }} />
-            <h4>{paletteDetails.hex3}</h4>
-          </div>
-          <div className="d-flex flex-column text-center">
-            <div className="color-display" style={{ backgroundColor: `${paletteDetails.hex4}` }} />
-            <h4>{paletteDetails.hex4}</h4>
-          </div>
-          <div className="d-flex flex-column text-center">
-            <div className="color-display" style={{ backgroundColor: `${paletteDetails.hex5}` }} />
-            <h4>{paletteDetails.hex5}</h4>
-          </div>
+          {palettedColors.map((color) => (
+            <>
+              <div className="d-flex flex-column text-center">
+                <div className="color-display" style={{ backgroundColor: `${color.hex1}` }} />
+                <h4>{color.hex1}</h4>
+              </div>
+              <div className="d-flex flex-column text-center">
+                <div className="color-display" style={{ backgroundColor: `${color.hex2}` }} />
+                <h4>{color.hex2}</h4>
+              </div>
+              <div className="d-flex flex-column text-center">
+                <div className="color-display" style={{ backgroundColor: `${color.hex3}` }} />
+                <h4>{color.hex3}</h4>
+              </div>
+              <div className="d-flex flex-column text-center">
+                <div className="color-display" style={{ backgroundColor: `${color.hex4}` }} />
+                <h4>{color.hex4}</h4>
+              </div>
+              <div className="d-flex flex-column text-center">
+                <div className="color-display" style={{ backgroundColor: `${color.hex5}` }} />
+                <h4>{color.hex5}</h4>
+              </div>
+            </>
+          ))}
         </div>
-        <div className="btn-group center">
+        <div className="btn-group center mt-5">
           <NewPaletteForm obj={paletteDetails} />
-          <Button size="lg" variant="danger" className="basic-btn mt-4 center">DELETE</Button>
         </div>
       </div>
     </>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -35,14 +35,10 @@ body {
   gap: 5px;
 }
 
-.generate-btn, .save-btn {
-  margin-top: 20px;
+.save-btn {
   border: 2px solid black;
   background-color: transparent;
   border-radius: 10px;
-  width: auto;
-  height: 40px;
-  color: black;
 }
 
 .save-btn {
@@ -96,4 +92,13 @@ body {
   text-align: center;
   text-shadow: 1px black;
   font-size: 14px;
+}
+
+.palette-btn {
+  float: bottom;
+}
+
+.bg-black {
+  background-color: black;
+  color: white;
 }


### PR DESCRIPTION
### Creating a palette now separates into two separate nodes:
- first node being the palette node in the database, hosting the fbK, title, description, and uid
- second node being the palettedColors node, that hosts the 5 different hex values, unique identifier, and a paletteId

### Update is now fixed; before you had to hard refresh for PATCH to render, now you dont!
### Added a new palettedColors file inside the api folder for respective requests. 